### PR TITLE
Added multiple authors option

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -77,7 +77,8 @@
 		#let count = author.len()
 		#let ncols = calc.min(count, 3)
 		#grid(
-			columns: (1fr,) * ncols,
+			columns: (auto,) * ncols,
+			column-gutter: 16pt,
 			row-gutter: 24pt,
 			..author.map(author => {
 				author.name

--- a/template.typ
+++ b/template.typ
@@ -44,9 +44,10 @@
 ) = {
 	// Prefer authors array over single author
 	authors = if (authors != none) { authors } else { ((name: author),) }
+	author = if (author != none) { author } else { authors.first().name }
 
 	// Set the metadata.
-	set document(title: title, author: authors.first().name)
+	set document(title: title, author: author)
 
 	// Configure page and text properties.
 	set text(font: "PT Sans", weight: "regular")

--- a/template.typ
+++ b/template.typ
@@ -27,6 +27,9 @@
 	// The presentation's author, which is displayed on the title slide.
 	author: none,
 
+	// The presentation's authors, which are displayed on the title slide.
+	authors: none,
+
 	// The date, displayed on the title slide.
 	date: none,
 
@@ -39,8 +42,11 @@
 	// The presentation's content.
 	body
 ) = {
+	// Prefer authors array over single author
+	authors = if (authors != none) { authors } else { ((name: author),) }
+
 	// Set the metadata.
-	set document(title: title, author: author)
+	set document(title: title, author: authors.first().name)
 
 	// Configure page and text properties.
 	set text(font: "PT Sans", weight: "regular")
@@ -63,16 +69,32 @@
 	)
 
 	// Display the title page.
-	page(background: none, header: none, footer: none)[
-		#set align(center+horizon)
-		#set text(24pt, weight: "light")
-		#title
+	page(background: none, header: none, footer: none, {
+		set align(center+horizon)
+		set text(24pt, weight: "light")
+		title
 
-		#set text(14pt)
-		#author
+		set text(14pt)
+		let count = authors.len()
+		let ncols = calc.min(count, 3)
+		grid(
+			columns: (1fr,) * ncols,
+			row-gutter: 24pt,
+			..authors.map(author => {
+				author.name
+				if (author.keys().contains("affiliation")) {
+					linebreak()
+					author.affiliation
+				}
+				if (author.keys().contains("email")) {
+					linebreak()
+					link("mailto:" + author.email)
+				}
+			}),
+		)
 
-		#text(features: ("case",))[#date]
-	]
+		text(features: ("case",))[#date]
+	})
 
 	// Customize headings to show new slides.
 	show heading: set text(font: "Avenir")

--- a/template.typ
+++ b/template.typ
@@ -27,9 +27,6 @@
 	// The presentation's author, which is displayed on the title slide.
 	author: none,
 
-	// The presentation's authors, which are displayed on the title slide.
-	authors: none,
-
 	// The date, displayed on the title slide.
 	date: none,
 
@@ -42,12 +39,13 @@
 	// The presentation's content.
 	body
 ) = {
-	// Prefer authors array over single author
-	authors = if (authors != none) { authors } else { ((name: author),) }
-	author = if (author != none) { author } else { authors.first().name }
+	// Ensure that the type of `author` is an array
+	author = if type(author) == "string" { ((name: author),) }
+		else if type(author) == "array" { author }
+		else { panic("expected string or array, found " + type(author)) }
 
 	// Set the metadata.
-	set document(title: title, author: author)
+	set document(title: title, author: author.map(author => author.name))
 
 	// Configure page and text properties.
 	set text(font: "PT Sans", weight: "regular")
@@ -70,18 +68,18 @@
 	)
 
 	// Display the title page.
-	page(background: none, header: none, footer: none, {
-		set align(center+horizon)
-		set text(24pt, weight: "light")
-		title
+	page(background: none, header: none, footer: none)[
+		#set align(center+horizon)
+		#set text(24pt, weight: "light")
+		#title
 
-		set text(14pt)
-		let count = authors.len()
-		let ncols = calc.min(count, 3)
-		grid(
+		#set text(14pt)
+		#let count = author.len()
+		#let ncols = calc.min(count, 3)
+		#grid(
 			columns: (1fr,) * ncols,
 			row-gutter: 24pt,
-			..authors.map(author => {
+			..author.map(author => {
 				author.name
 				if (author.keys().contains("affiliation")) {
 					linebreak()
@@ -94,8 +92,8 @@
 			}),
 		)
 
-		text(features: ("case",))[#date]
-	})
+		#text(features: ("case",))[#date]
+	]
 
 	// Customize headings to show new slides.
 	show heading: set text(font: "Avenir")


### PR DESCRIPTION
Hey!
I'm using this library for quite a while now, due to it's simplicity and ease-of-use. Thank you for the good work.

Here is an improvement to the authors details section.

- Added an argument to add multiple `authors` along with existing `author` argument.
- For title slide, `authors` is preferred over `author` when both are available.
- For document author, `author` is preferred when both are available, else first author is used.
- Authors can now display their `affiliation` as well as `email` address.

Keeping both options seems to complicate the behavior. What are your thoughts?

I did not change anything in examples, as I did not have the `Avenir` font to recompile.

**Edit:** May be the document `author` can be reset by the user if it's different than the first author? and we don't allow passing both arguments together to avoid uncertainty.